### PR TITLE
Add bangumi iframe support

### DIFF
--- a/bilibili-macOS-PIP.safariextension/PIP.js
+++ b/bilibili-macOS-PIP.safariextension/PIP.js
@@ -15,7 +15,11 @@ if (re.exec(window.location.href) != null || bangumi.exec(window.location.href))
             var enabled = false; \
             function native_player(btn) {\
                 function enable_native(e) {\
-                    var player = document.getElementsByTagName("video")[0];\
+                    if (re.exec(window.location.href) != null) {\
+                        var player = document.getElementsByTagName("video")[0];\
+                    } else {\
+                        var player = document.getElementsByClassName("bilibiliHtml5Player")[0].contentDocument.getElementsByTagName("video")[0];\
+                    }\
                     console.log("Did Set!");\
                     if (e) {\
                         player.setAttribute("controls", "controls");\


### PR DESCRIPTION
Get the HTML5 video tag in `<iframe>` in Bilibili bangumi pages.

无法正常获取 `<video>` 标签使得插件对 Bangumi 新番视频无效，已修正。
